### PR TITLE
fix c89 for loops

### DIFF
--- a/libdebug/libdebug.c
+++ b/libdebug/libdebug.c
@@ -114,11 +114,12 @@ static void backtrace_handler(int sig_num, siginfo_t *info, void *ucontext)
 
 int debug_backtrace_init(void)
 {
+    uint32_t i;
     struct sigaction sigact;
     sigact.sa_sigaction = backtrace_handler;
     sigact.sa_flags = SA_RESTART | SA_SIGINFO;
     int ret = 0;
-    for (uint32_t i = 0; i < (sizeof(signum) / sizeof(uint32_t)); ++i) {
+    for (i = 0; i < (sizeof(signum) / sizeof(uint32_t)); ++i) {
         if (sigaction(signum[i], &sigact, NULL) != 0) {
             fprintf(stderr, "Failed to set signal handler for %s(%d)!",
                   strsignal(signum[i]),

--- a/liblock/test_liblock.c
+++ b/liblock/test_liblock.c
@@ -40,9 +40,10 @@ static void *print_mutex_lock(void *arg)
     struct thread_arg *argp = (struct thread_arg *)arg;
     int c = argp->flag;
     uint64_t n = argp->count;
+    uint64_t i;
     pthread_t tid = pthread_self();
     printf("c = %d\n", c);
-    for (uint64_t i = 0; i < n; ++ i) {
+    for (i = 0; i < n; ++ i) {
         if (c) {
             mutex_lock(mutex);
             ++ value;
@@ -66,10 +67,11 @@ static void *print_spin_lock(void *arg)
     struct thread_arg *argp = (struct thread_arg *)arg;
     int c = argp->flag;
     uint64_t n = argp->count;
+    uint64_t i;
     pthread_t tid = pthread_self();
 
     printf("c = %d\n", c);
-    for (uint64_t i = 0; i < n; ++ i) {
+    for (i = 0; i < n; ++ i) {
         if (c) {
             spin_lock(spin);
             ++ value;


### PR DESCRIPTION
just moving some variable declaration to top of function, for making a c89-compatible code.