### PR TITLE
change macro `MAX_V4L_REQBUF_CNT` definition

### DIFF
--- a/libuvc/libuvc.c
+++ b/libuvc/libuvc.c
@@ -55,7 +55,7 @@ static const uint32_t v4l2_cid_supported[] = {
 
 #define MAX_V4L2_CID        (sizeof(v4l2_cid_supported)/sizeof(uint32_t))
 #define MAX_V4L_BUF         (32)
-#define MAX_V4L_REQBUF_CNT  (256)
+#define MAX_V4L_REQBUF_CNT  (4)
 
 struct frame {
     struct iovec buf;


### PR DESCRIPTION
change MAX_V4L_REQBUF_CNT macro definition. 

Orignal max buffer count is defined 256. The definition is OK in my PC environment, but fails in ARM device. I test the max count is not greater than 64. In general, the req count is set 4, as referred as refer: https://www.kernel.org/doc/html/v4.11/media/uapi/v4l/capture.c.html

When request count is more than 64, ioctl(VIDIOC_QUERYBUF) failed: 22.

I guess the request count = 4 should be more safe for all scenarios.